### PR TITLE
Support generating Yard documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,11 @@
 
 .data/
 .bundle/
+doc/
 log/
 tmp/
 .idea/
-
+.yardoc/
 .rspec_status
 
 .local_files

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,1 @@
+--markup=markdown

--- a/randrizer.gemspec
+++ b/randrizer.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "pry-byebug", "~> 3.8.0"
   spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "redcarpet", "~> 3.5.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec_junit_formatter", "0.4.1"
   spec.add_development_dependency "rubocop", "~> 0.80.0"


### PR DESCRIPTION
Requires `redcarpet` to properly support markdown-like syntax