### PR TITLE
Enable more cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -68,6 +68,15 @@ Layout/FirstHashElementIndentation:
 Style/YodaCondition:
   Enabled: true
 
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
 RSpec/ExampleLength:
   Enabled: false
 


### PR DESCRIPTION
Resolves the following warning that rubocop is now emitting:

```
The following cops were added to RuboCop, but are not configured. Please set
Enabled to either `true` or `false` in your `.rubocop.yml` file:
```