### PR TITLE
Add a type expander

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,24 @@ Randrizer is a small library that allows consumers to generate random data
 for testing.
 
 ```ruby
-irb(main):001:0> definition = Randrizer::Types::Dict[{
-  Randrizer::Types::Const["hello"] => Randrizer::Types::String[],
-  Randrizer::Types::Const["world"] => Randrizer::Types::Int[min: 5, max: 10],
-  Randrizer::Types::Const["nested"] => Randrizer::Types::Dict[
-    {
-      Randrizer::Types::Const["nested1"] => Randrizer::Types::Float[],
-      Randrizer::Types::Optional[inner_type: Randrizer::Types::Const["nested2"]] =>
-        Randrizer::Types::Int[]
-    }
-  ]
-}]
+definition = {
+  "this is" => "a constant",
+  "but this should be a random positive number" => Randrizer::Types::Int[min: 1, max: 10],
+  "and we support nested objects" => {
+    "which can also be nested" => [
+      Randrizer::Types::String[min_length: 3, max_length: 4, valid_chars: "ABC"],
+      Randrizer::Types::Int[min: 0, max: 1000],
+      Randrizer::Types::OneOf.build("choice 1", "choice 2", "choice 3")
+    ]
+  }
+}
 
-irb(main):002:0> definition.eval
-=> {"hello"=>"XN3#tQd1%5#HWXI*p9zJD!tV^\\e%Wgais]vJQRNp$Z60FymI[=8~xy0IdVrmSb)me59zbqJjTbgZsv1NQA",
- "world"=>6,
- "nested"=>{"nested1"=>2274302953.724733}}
+Randrizer::Generator.generate(definition)
+```
+```ruby
+=> {"this is"=>"a constant",
+ "but this should be a random positive number"=>7,
+ "and we support nested objects"=>{"which can also be nested"=>["BBB", 828, "choice 2"]}}
 ```
 
 ## Use cases

--- a/lib/randrizer/drivers/json_schema/typegen.rb
+++ b/lib/randrizer/drivers/json_schema/typegen.rb
@@ -24,15 +24,15 @@ module Randrizer
             DAY_INT_TYPE
           ].freeze
 
-          TIMEZONE_SEQUENCE = Types::OneOf.build([
+          TIMEZONE_SEQUENCE = Types::OneOf.build(
             Types::Const["Z"],
-            Types::StringSequence.build([
-              Types::OneOf.build([Types::Const["+"], Types::Const["-"]]),
+            Types::StringSequence.build(
+              Types::OneOf.build(Types::Const["+"], Types::Const["-"]),
               HOUR_INT_TYPE,
               Types::Const[":"],
               MIN_SEC_INT_TYPE
-            ])
-          ])
+            )
+          )
 
           TIME_SEQUENCE = [
             HOUR_INT_TYPE,
@@ -81,17 +81,17 @@ module Randrizer
 
             case format
             when "date"
-              Types::StringSequence.build(DATE_SEQUENCE)
+              Types::StringSequence.build(*DATE_SEQUENCE)
             when "time"
-              Types::StringSequence.build(TIME_SEQUENCE)
+              Types::StringSequence.build(*TIME_SEQUENCE)
             when "date-time"
-              Types::StringSequence.build([
-                DATE_SEQUENCE,
+              Types::StringSequence.build(
+                *DATE_SEQUENCE,
                 Types::Const["T"],
-                TIME_SEQUENCE
-              ].flatten)
+                *TIME_SEQUENCE
+              )
             when "email"
-              Types::StringSequence.build(EMAIL_SEQUENCE)
+              Types::StringSequence.build(*EMAIL_SEQUENCE)
             else
               raise "Format not supported: #{format}"
             end

--- a/lib/randrizer/generator.rb
+++ b/lib/randrizer/generator.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 require "randrizer/types"
+require "randrizer/types/type_expansion"
 
 module Randrizer
   class Generator
     def self.generate(type)
-      type.validate!
-      type.eval
+      type_tree = Types::TypeExpansion.expand_for(type)
+
+      type_tree.validate!
+      type_tree.eval
     end
   end
 end

--- a/lib/randrizer/types.rb
+++ b/lib/randrizer/types.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# Base class for all the types
+require "randrizer/types/base_type"
+
 # Primitive types. They should not depend on each other.
 require "randrizer/types/const"
 require "randrizer/types/bool"

--- a/lib/randrizer/types/list.rb
+++ b/lib/randrizer/types/list.rb
@@ -25,7 +25,9 @@ module Randrizer
       end
 
       def eval
-        @list_def.map(&:eval).reject { |evaluated| evaluated == SKIP }
+        @list_def.map { |item| TypeExpansion.expand_for(item).eval }.reject do |evaluated|
+          evaluated == SKIP
+        end
       end
 
       def empty?

--- a/lib/randrizer/types/nullable.rb
+++ b/lib/randrizer/types/nullable.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "randrizer/types/base_type"
+require "randrizer/types/type_expansion"
 
 module Randrizer
   module Types
@@ -28,7 +29,7 @@ module Randrizer
       def eval
         return nil if rand > (1.0 - @null_prob)
 
-        @inner_type.eval
+        TypeExpansion.expand_for(@inner_type).eval
       end
     end
   end

--- a/lib/randrizer/types/one_of.rb
+++ b/lib/randrizer/types/one_of.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "randrizer/types/base_type"
+require "randrizer/types/type_expansion"
 
 module Randrizer
   module Types
@@ -24,7 +25,7 @@ module Randrizer
       end
 
       def eval
-        @list_def.sample.eval
+        TypeExpansion.expand_for(@list_def.sample).eval
       end
 
       def length

--- a/lib/randrizer/types/optional.rb
+++ b/lib/randrizer/types/optional.rb
@@ -2,6 +2,7 @@
 
 require "randrizer/types/skip"
 require "randrizer/types/base_type"
+require "randrizer/types/type_expansion"
 
 module Randrizer
   module Types
@@ -31,7 +32,7 @@ module Randrizer
       def eval
         return SKIP if rand > @presence_prob
 
-        @inner_type.eval
+        TypeExpansion.expand_for(@inner_type).eval
       end
     end
   end

--- a/lib/randrizer/types/skip.rb
+++ b/lib/randrizer/types/skip.rb
@@ -4,6 +4,7 @@ require "randrizer/types/base_type"
 
 module Randrizer
   module Types
+    # Special type to be skipped when encountered by iterable types.
     class Skip
       include BaseType
 

--- a/lib/randrizer/types/string_sequence.rb
+++ b/lib/randrizer/types/string_sequence.rb
@@ -17,29 +17,40 @@ module Randrizer
       ].freeze
 
       class << self
-        def build(sequence_def)
-          new(sequence_def)
+        def build(*sequence_def)
+          new(*sequence_def)
         end
 
         alias [] build
       end
 
-      def initialize(sequence_def)
+      def initialize(*sequence_def)
         @sequence_def = sequence_def
       end
 
       def validate!
-        disallowed = @sequence_def.reject { |item| ALLOWED_TYPES.include?(item.class) }
+        disallowed = expanded_sequence
+                     .reject { |item| ALLOWED_TYPES.include?(item.class) }
 
         raise ValidationError("types not allowed in a string sequence: #{disallowed}")
       end
 
       def eval
-        @sequence_def.map(&:eval).reject { |evaluated| evaluated == SKIP }.compact.join
+        expanded_sequence
+          .map(&:eval)
+          .reject { |evaluated| evaluated == SKIP }
+          .compact
+          .join
       end
 
       def empty?
-        @sequence_def.empty?
+        expanded_sequence.empty?
+      end
+
+      private
+
+      def expanded_sequence
+        @expanded_sequence ||= @sequence_def.map { |t| TypeExpansion.expand_for(t) }
       end
     end
   end

--- a/lib/randrizer/types/type_expansion.rb
+++ b/lib/randrizer/types/type_expansion.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "randrizer/types"
+
+module Randrizer
+  module Types
+    class TypeExpansion
+      # Combines ruby's native types with randrizer types.
+      #
+      # @param [Object] type
+      #   returns a version of the type that can be used as a base for a type tree
+      # @return [Randrizer::Types::BaseType] a type-tree ready type
+      def self.expand_for(type)
+        case type
+        when BaseType
+          # If it's one of our own types just return it as it is
+          type
+        when ::Array
+          Types::List.build(
+            *type.map { |entry| expand_for(entry) }
+          )
+        when ::Hash
+          hash_def = type.each_with_object({}) do |(k, v), acc|
+            key_type = expand_for(k)
+            value_type = expand_for(v)
+            acc[key_type] = value_type
+          end
+
+          Types::Dict.build(hash_def)
+        when ::Integer, ::Float,
+             ::String, ::Symbol
+          Types::Const.build(type)
+        when nil
+          Types::Const.build(nil)
+        else
+          raise "Unsupported type: #{type.class} (#{type})"
+        end
+      end
+    end
+  end
+end

--- a/spec/randrizer/generator_spec.rb
+++ b/spec/randrizer/generator_spec.rb
@@ -122,5 +122,33 @@ RSpec.describe Randrizer::Generator do
         it { expect(described_class.generate(input)).to eq("yolo") }
       end
     end
+
+    context "when type expansion is required" do
+      let(:partial_type_tree) do
+        {
+          "string 1" => "constant 1",
+          "string 2" => "constant 2",
+          "number 1" => 1234,
+          "inner" => {
+            "hello" => "world",
+            "random" => Randrizer::Types::Int[]
+          }
+        }
+      end
+
+      it "expands the type tree keeping the constants" do
+        output = described_class.generate(partial_type_tree)
+
+        expect(output).to match({
+          "string 1" => "constant 1",
+          "string 2" => "constant 2",
+          "number 1" => 1234,
+          "inner" => {
+            "hello" => "world",
+            "random" => an_instance_of(Integer)
+          }
+        })
+      end
+    end
   end
 end

--- a/spec/randrizer/types/string_sequence_spec.rb
+++ b/spec/randrizer/types/string_sequence_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 require "randrizer/types"
 
 RSpec.describe Randrizer::Types::StringSequence do
-  let(:instance) { described_class[params] }
+  let(:instance) { described_class[*params] }
 
   let(:string_def) { Randrizer::Types::String[min_length: 4, max_length: 10] }
   let(:int_def) { Randrizer::Types::Int[min: 4, max: 10] }
@@ -54,6 +54,15 @@ RSpec.describe Randrizer::Types::StringSequence do
           is_expected.to be_an_instance_of(String)
           expect(subject).to include("optional")
         end
+      end
+    end
+
+    context "when the sequence types need to be expanded" do
+      let(:params) { [int_def, "a constant"] }
+
+      it "expands the types correctly" do
+        is_expected.to be_an_instance_of(String)
+        expect(subject).to include("a constant")
       end
     end
   end

--- a/spec/randrizer/types/type_expansion_spec.rb
+++ b/spec/randrizer/types/type_expansion_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "randrizer/types/type_expansion"
+
+RSpec.describe Randrizer::Types::TypeExpansion do
+  describe "#expand_for" do
+    let(:short_string) do
+      Randrizer::Types::String.build(
+        max_length: 3,
+        valid_chars: Randrizer::Types::String::CHARS_LOWERCASE_LETTERS
+      )
+    end
+
+    context "with constant values" do
+      let(:const) { 123 }
+
+      context "when the constant is a string" do
+        let(:const) { "a string" }
+
+        it do
+          expanded = described_class.expand_for(const)
+
+          expect(expanded).to be_an_instance_of(Randrizer::Types::Const)
+          expect(expanded.eval).to eq(const)
+        end
+      end
+
+      context "when the constant is an integer" do
+        let(:const) { 1234 }
+
+        it do
+          expanded = described_class.expand_for(const)
+
+          expect(expanded).to be_an_instance_of(Randrizer::Types::Const)
+          expect(expanded.eval).to eq(const)
+        end
+      end
+
+      context "when the constant is a float" do
+        let(:const) { 1234.56 }
+
+        it do
+          expanded = described_class.expand_for(const)
+
+          expect(expanded).to be_an_instance_of(Randrizer::Types::Const)
+          expect(expanded.eval).to eq(const)
+        end
+      end
+
+      context "when the constant is nil" do
+        let(:const) { nil }
+
+        it do
+          expanded = described_class.expand_for(const)
+
+          expect(expanded).to be_an_instance_of(Randrizer::Types::Const)
+          expect(expanded.eval).to be_nil
+        end
+      end
+    end
+
+    context "with a list" do
+      let(:list) { [1, 2, 3] }
+
+      it do
+        expanded = described_class.expand_for(list)
+
+        expect(expanded).to be_an_instance_of(Randrizer::Types::List)
+        expect(expanded).not_to be_empty
+        expect(expanded.eval).to eq([1, 2, 3])
+      end
+
+      context "when the list includes other randrizer types" do
+        let(:list) do
+          [
+            Randrizer::Types::Const["yolo"],
+            short_string
+          ]
+        end
+
+        it do
+          expanded = described_class.expand_for(list)
+
+          expect(expanded).to be_an_instance_of(Randrizer::Types::List)
+          expect(expanded).not_to be_empty
+          expect(expanded.eval).to match(["yolo", /[a-z]{,3}/])
+        end
+      end
+    end
+
+    context "with a hash" do
+      let(:hash) { { "yolo" => 1234 } }
+
+      it do
+        expanded = described_class.expand_for(hash)
+
+        expect(expanded).to be_an_instance_of(Randrizer::Types::Dict)
+        expect(expanded.eval).to eq(hash)
+      end
+
+      context "when the hash includes a randrizer type" do
+        let(:hash) { { "yolo" => short_string } }
+
+        it do
+          expanded = described_class.expand_for(hash)
+
+          expect(expanded).to be_an_instance_of(Randrizer::Types::Dict)
+          expect(expanded.eval).to match({ "yolo" => /[a-z]{,3}/ })
+        end
+      end
+
+      context "when the hash includes nested hashes" do
+        let(:hash) do
+          {
+            "yolo" => {
+              "hello" => "world"
+            }
+          }
+        end
+
+        it do
+          expanded = described_class.expand_for(hash)
+
+          expect(expanded).to be_an_instance_of(Randrizer::Types::Dict)
+          expect(expanded.eval).to match({ "yolo" => { "hello" => "world" } })
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows to define partial type trees, i.e. type trees where some
items have been defined as primitive types (and that should be defined
as constants).

For example given an object like:
```
{
  "string 1" => "constant 1",
  "string 2" => "constant 2",
  "number 1" => 1234,
  "inner" => {
    "hello" => "world",
    "random" => Randrizer::Types::Int[]
  }
}
```

It will generate a hash in output that has the same structure but where
`hash["inner"]["random"]` has a random integer value.

This is very useful to quickly compose type trees when the structure of
the output is not composed programmatically.